### PR TITLE
Quality of life changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ suits my needs better than the builtins. Here are the choices I made:
      `lo_unchecked()` or `hi_unchecked()`, which are marked unsafe as they
      do not reflect the significant `lo <= hi` invariant.
 
-  4. All nonempty cases have `lo <= hi` enforced in `new`. If you pass `hi >
-     lo` to `new`, the values are swapped (i.e. you can construct from
+  4. All nonempty cases have `lo <= hi` enforced in `new`. If you pass `lo >
+     hi` to `new`, the values are swapped (i.e. you can construct from
      either order of points; they get stored in order). If you are
      constructing from raw IO values you can do `new_unchecked` which will
      not swap, only normalize unordered ranges to `empty()`, and is also

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,15 @@ impl<N: PrimInt> Extent<N> {
     }
 }
 
+impl<N: PrimInt> IntoIterator for Extent<N> {
+    type Item = N;
+    type IntoIter = ExtentIter<N>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct ExtentIter<N: PrimInt>(Extent<N>);
 


### PR DESCRIPTION
- fixed a typo in README (about lo/hi invariant)
- implemented `IntoIterator` for `Extent`
- added the default Rust workflow